### PR TITLE
More standard installation with requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,20 @@
 This utalizes OpenAI's Whisper python library and a simple gmail python client to monitor an email address, automatically read the email/download its attachment, and then respond with the transcription of the audio/video file.
 This is intended to help transcribe voicemails from PBX systems and other audio files.
 
-__Note:__ Requires the simplegmail library from jeremyephron/simplegmail. Simply install by running
+### Installation
 
-``` pip install simplegmail ```
+```bash
+pip install -r requirements.txt
+```
 
-See [their repository](https://github.com/jeremyephron/simplegmail) for login and setup instructions
+__Note:__ Dependency [jeremyephron/simplegmail](https://github.com/jeremyephron/simplegmail) requires gmail login configuration. See their repository for instructions.
 
 Also, due to outdated oauth2 libraries and an updated google authentication process, you will need to make an adjustment to the oauth2client library, specifically the oauth2client/client.py file.
 Find the line labeled ```OOB_CALLBACK_URN``` and replace its contents with ```http://localhost```
 
 Also, since I'm lazy and don't want to mess around with secrets, create and populate a file in the root directory of this project named __sender_email.txt__ with only the email address you intend to send your transcriptions through. Typically, this will be the email address you authenticate with Google, but there are some worlds where it might be different.
 
-__Todo:__
+### TODO
 
-- Add whitelists to only open emails from certain addresses.
+- [ ] Add whitelists to only open emails from certain addresses.
  

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+rich==14.0.0
+simplegmail==4.1.1
+whisper==1.1.10


### PR DESCRIPTION
Common practice is to install dependencies with `pip install -r requirements.txt`. Also, this includes already existing but unmentioned dependencies `rich` and `whisper`.